### PR TITLE
fix(status): show /shadow status event times in local timezone

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -286,7 +286,7 @@ export class ShadowMindRuntime {
       ...this.recentEvents.slice(-5).map((event) => {
         const failed = event.kind === "run-end" && (event.data?.reason === "error" || event.data?.reason === "timeout");
         const detail = failed ? ` ${event.data?.error ?? event.data?.reason}` : "";
-        return `${event.at.slice(11, 19)} ${event.kind}${detail}`;
+        return `${new Date(event.at).toLocaleTimeString("en-GB", { hour12: false })} ${event.kind}${detail}`;
       }),
       "Commands: /shadow pause | resume | status | hide",
     ];


### PR DESCRIPTION
## Problem

`/shadow status` slices the ISO timestamp directly:

```ts
event.at.slice(11, 19)
```

`event.at` is stored as a UTC ISO string (e.g. `2026-08-16T07:00:00.000Z`), so the status panel always shows **UTC hours** instead of the user's local time. In UTC+8, the panel reads 8 hours behind the system clock.

## Fix

```ts
new Date(event.at).toLocaleTimeString("en-GB", { hour12: false })
```

`Date` converts to the Node process's local timezone, so the panel now matches the system clock.

## Verification

- `npm run verify` passes (typecheck + 47 tests)
- Local check: `2026-08-16T15:00:00.000Z` → `23:00:00` under `TZ=Asia/Shanghai`