### PR TITLE
fix(runner): reload resource loader to enable extension providers in shadow session

### DIFF
--- a/src/shadow-runner.ts
+++ b/src/shadow-runner.ts
@@ -209,6 +209,7 @@ export class ShadowRunner {
         extensions: base.extensions.filter((extension) => !isSelfExtension(extension.resolvedPath)),
       }),
     });
+    await resourceLoader.reload();
     const reportTool = createReportTool((content) => {
       if (state.reported || controller.signal.aborted) return;
       state.reported = true;


### PR DESCRIPTION
## Summary
Reload the shadow session's `DefaultResourceLoader` during `ShadowRunner.bootstrapSession`.

## Problem
When `DefaultResourceLoader` is instantiated without calling `reload()`, its loaded extensions list remains empty (`getExtensions().extensions === []`). As a result, custom provider extensions (such as `pi-antigravity`) were never initialized in the shadow session's `ModelRuntime`, causing shadow runs targeting extension-provided models to fail with provider/auth errors (e.g. `No API key found for antigravity`).

## Solution
Add `await resourceLoader.reload()` before creating the child session via `createAgentSession`. This ensures that extension-registered providers, OAuth handlers, and stream functions are properly registered in the child runtime while maintaining existing self-extension filtering.

## Verification
- Verified with `npm run verify` (all 16 test suites / 68 tests pass and typecheck passes).